### PR TITLE
whyred: move goodix firmware to /vendor/firmware

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -61,10 +61,12 @@ extract "$MY_DIR"/proprietary-files-twrp.txt "$SRC" "$SECTION"
 TWRP_QSEECOMD="$LINEAGE_ROOT"/vendor/"$VENDOR"/"$DEVICE"/proprietary/recovery/root/sbin/qseecomd
 TWRP_GATEKEEPER="$LINEAGE_ROOT"/vendor/"$VENDOR"/"$DEVICE"/proprietary/recovery/root/sbin/android.hardware.gatekeeper@1.0-service
 TWRP_KEYMASTER="$LINEAGE_ROOT"/vendor/"$VENDOR"/"$DEVICE"/proprietary/recovery/root/sbin/android.hardware.keymaster@3.0-service
+GOODIX="$LINEAGE_ROOT"/vendor/"$VENDOR"/"$DEVICE"/proprietary/vendor/lib64/libgf_ca.so
 
 sed -i "s|/system/bin/linker64|/sbin/linker64\x0\x0\x0\x0\x0\x0|g" "$TWRP_QSEECOMD"
 sed -i "s|/system/bin/linker64|/sbin/linker64\x0\x0\x0\x0\x0\x0|g" "$TWRP_GATEKEEPER"
 sed -i "s|/system/bin/linker64|/sbin/linker64\x0\x0\x0\x0\x0\x0|g" "$TWRP_KEYMASTER"
+sed -i "s|/system/etc/firmware|/vendor/firmware\x0\x0\x0\x0|g" $GOODIX
 
 BLOB_ROOT="$LINEAGE_ROOT"/vendor/"$VENDOR"/"$DEVICE"/proprietary
 patchelf --set-soname libicuuc-v27.so $BLOB_ROOT/vendor/lib/libicuuc-v27.so

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -1023,15 +1023,15 @@ vendor/lib/hw/vendor.qti.esepowermanager@1.0-impl.so|a56027dc75c8c71e5c2163e674d
 vendor/lib64/hw/vendor.qti.esepowermanager@1.0-impl.so|6b4a3df201146ce2510f38addd27e5a12fa7d107
 
 # Fingerprint firmware
-etc/firmware/goodixfp.b00
-etc/firmware/goodixfp.b01
-etc/firmware/goodixfp.b02
-etc/firmware/goodixfp.b03
-etc/firmware/goodixfp.b04
-etc/firmware/goodixfp.b05
-etc/firmware/goodixfp.b06
-etc/firmware/goodixfp.b07
-etc/firmware/goodixfp.mdt
+system/etc/firmware/goodixfp.b00:vendor/firmware/goodixfp.b00
+system/etc/firmware/goodixfp.b01:vendor/firmware/goodixfp.b01
+system/etc/firmware/goodixfp.b02:vendor/firmware/goodixfp.b02
+system/etc/firmware/goodixfp.b03:vendor/firmware/goodixfp.b03
+system/etc/firmware/goodixfp.b04:vendor/firmware/goodixfp.b04
+system/etc/firmware/goodixfp.b05:vendor/firmware/goodixfp.b05
+system/etc/firmware/goodixfp.b06:vendor/firmware/goodixfp.b06
+system/etc/firmware/goodixfp.b07:vendor/firmware/goodixfp.b07
+system/etc/firmware/goodixfp.mdt:vendor/firmware/goodixfp.mdt
 vendor/firmware/fpctzappfingerprint.b00
 vendor/firmware/fpctzappfingerprint.b01
 vendor/firmware/fpctzappfingerprint.b02


### PR DESCRIPTION
Edit libgf_ca.so to look in /vendor/firmware instead of /system/etc/firmware as it only checked in
/system/etc/firmware and /firmware/image

Signed-off-by: Akhil Narang <akhilnarang.1999@gmail.com>